### PR TITLE
Fix cloud images with the same template VM

### DIFF
--- a/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudClient.kt
+++ b/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudClient.kt
@@ -119,7 +119,6 @@ class ICCloudClient(
 
             val imageInstanceFolder = image.optString("instanceFolder") ?: imageTemplate.substring(0, sepIndex)
 
-            val imageId = imageTemplate.substring(sepIndex + 1)
             val vm = vim.authenticated {
                 port.findByInventoryPath(serviceContent.searchIndex, imageTemplate)
             }
@@ -141,7 +140,7 @@ class ICCloudClient(
                 else -> throw RuntimeException("Invalid network configuration")
             }
 
-            createImage(imageId, imageName, vm, folder, maxInstances, networks)
+            createImage(imageName, imageName, vm, folder, maxInstances, networks)
         }
     }
 }


### PR DESCRIPTION
The name of the template was used as the image identifier, meaning
that for two images with the same template, only one would be visible to TC.
This change fixes the problem by using the image name as the image identifier.