### PR TITLE
Remove agent instances early

### DIFF
--- a/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudClient.kt
+++ b/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudClient.kt
@@ -5,9 +5,12 @@ import jetbrains.buildServer.clouds.*
 import jetbrains.buildServer.serverSide.AgentDescription
 import jetbrains.buildServer.serverSide.BuildAgentManager
 import jetbrains.buildServer.serverSide.agentPools.AgentPoolManager
+import kotlinx.coroutines.asCoroutineDispatcher
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.*
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
 
 private val terminalStates = arrayOf(InstanceStatus.ERROR, InstanceStatus.ERROR_CANNOT_STOP, InstanceStatus.STOPPED)
 
@@ -17,6 +20,8 @@ class ICCloudClient(
         agentPoolManager: AgentPoolManager,
         val uuid: String,
         imageConfig: String) : CloudClientEx {
+
+    val coroutineDispatcher: CoroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 
     private fun setupImage(image: ICCloudImage) {
         val children = vim.getProperty(image.instanceFolder, "childEntity") as ArrayOfManagedObjectReference

--- a/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudImage.kt
+++ b/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudImage.kt
@@ -5,7 +5,7 @@ import jetbrains.buildServer.clouds.CloudErrorInfo
 import jetbrains.buildServer.clouds.CloudImage
 import jetbrains.buildServer.clouds.CloudInstance
 import jetbrains.buildServer.clouds.CloudInstanceUserData
-import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 class ICCloudImage(
         private val id: String,
@@ -14,11 +14,11 @@ class ICCloudImage(
         val instanceFolder: ManagedObjectReference,
         val maxInstances: Int,
         val networks: List<String>,
-        val agentPool: Int?,
+        private val agentPool: Int?,
         val profile: ICCloudClient) : CloudImage {
 
     private var instanceCounter = 0
-    private val instances = HashMap<String, ICCloudInstance>()
+    private val instances = ConcurrentHashMap<String, ICCloudInstance>()
 
     fun allocateName(): String {
         return "$name-${instanceCounter++}"

--- a/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudInstance.kt
+++ b/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudInstance.kt
@@ -170,6 +170,7 @@ class ICCloudInstance(
                 status = InstanceStatus.STOPPING
                 powerOff()
                 status = InstanceStatus.STOPPED
+                image.removeInstance(this@ICCloudInstance)
             } catch (e: Exception) {
                 errorInfo = CloudErrorInfo(e.message?: "", "", e)
                 status = InstanceStatus.ERROR_CANNOT_STOP


### PR DESCRIPTION
Currently, agent instances are left in stopped state until they get rolled away by new ones. This PR adds removal of all successfully stopped instances. Failed instances continue to be left in error state until rolled.