### PR TITLE
Shutdown guests gracefully when terminating an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ array of network names.
 5. Once ready, modify the agent's `build.properties` file by
    * deleting the authentication token (this ensures that each clone gets a new one) and by
    * setting `vmware.freeze.script` to a path to your freeze script (see below).
+   * Optionally, set `vmware.shutdown.script`.
 6. Wait a little. The agent will pick up the changes and restart. Just before registering
    to your TeamCity server, the agent will execute the freeze script, which should freeze your VM.
    Once cloned, the freeze script continues executing on the new machine.
@@ -78,7 +79,7 @@ to the path to the `rpctool` executable.
 
 Setting `vmware.freeze.script` will cause the agent to execute it during the next agent startup.
 
-## The Freeze Script
+## Freeze Script
 
 The simplest freeze script only performs the freeze, but you probably also want
 to restart networking, so as to have new clones pick up a new IP address.
@@ -90,3 +91,8 @@ On Windows, the script might be a .bat file and look like this.
 
 Adjust for other systems and your requirements.
 
+## Shutdown Script
+
+If set, the shutdown script is run after the agent has unregistered
+from the server, but before the machine is deleted.
+This is an ideal place to release the machine's IP address, for example.

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 
     <modules>
         <module>teamcity-stubs</module>
+        <module>vsphere-instaclone-common</module>
         <module>vsphere-instaclone-agent</module>
         <module>vsphere-instaclone-server</module>
         <module>build</module>

--- a/teamcity-stubs/src/main/java/jetbrains/buildServer/agent/impl/BuildAgentEx.java
+++ b/teamcity-stubs/src/main/java/jetbrains/buildServer/agent/impl/BuildAgentEx.java
@@ -1,0 +1,7 @@
+package jetbrains.buildServer.agent.impl;
+
+import jetbrains.buildServer.agent.BuildAgent;
+
+public interface BuildAgentEx extends BuildAgent {
+    ServerMonitor getServerMonitor();
+}

--- a/teamcity-stubs/src/main/java/jetbrains/buildServer/agent/impl/ServerMonitor.java
+++ b/teamcity-stubs/src/main/java/jetbrains/buildServer/agent/impl/ServerMonitor.java
@@ -1,0 +1,7 @@
+package jetbrains.buildServer.agent.impl;
+
+public class ServerMonitor extends Thread {
+    public void shutdown() {
+        throw new RuntimeException("This is a stub and should not be called");
+    }
+}

--- a/teamcity-stubs/src/main/java/jetbrains/buildServer/remote/RemoteHandler.java
+++ b/teamcity-stubs/src/main/java/jetbrains/buildServer/remote/RemoteHandler.java
@@ -1,0 +1,15 @@
+package jetbrains.buildServer.remote;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RemoteHandler {
+    @NotNull
+    String handleName();
+}

--- a/teamcity-stubs/src/main/java/jetbrains/buildServer/serverSide/BuildAgentEx.java
+++ b/teamcity-stubs/src/main/java/jetbrains/buildServer/serverSide/BuildAgentEx.java
@@ -1,0 +1,7 @@
+package jetbrains.buildServer.serverSide;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface BuildAgentEx extends SBuildAgent {
+    <T> T getRemoteInterface(@NotNull Class<T> klass);
+}

--- a/vsphere-instaclone-agent/src/main/java/com/avast/teamcity/plugins/instaclone/RunningAgentPlugin.kt
+++ b/vsphere-instaclone-agent/src/main/java/com/avast/teamcity/plugins/instaclone/RunningAgentPlugin.kt
@@ -4,29 +4,27 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.diagnostic.Logger
 import jetbrains.buildServer.CommandLineExecutor
 import jetbrains.buildServer.agent.*
-import jetbrains.buildServer.util.EventDispatcher
+import jetbrains.buildServer.agent.impl.BuildAgentEx
 import org.json.JSONObject
 import java.io.File
+import java.time.Duration
 
-class VmwareInstacloneAgent(lifeCycleEvents: EventDispatcher<AgentLifeCycleListener>) {
+class RunningAgentPlugin(val agent: BuildAgent) : AgentService {
+
+    private val config = agent.configuration as BuildAgentConfigurationEx
+    private val rpcToolPath = findRpcTool(config)
 
     init {
-        lifeCycleEvents.addListener(object : AgentLifeCycleAdapter() {
-            override fun agentInitialized(agent: BuildAgent) {
-                initializeVmInstance(agent)
-            }
-        })
+        initialize()
     }
 
-    private fun initializeVmInstance(agent: BuildAgent) {
-        val config = agent.configuration as BuildAgentConfigurationEx
-        val rpcToolPath = findRpcTool(config)
+    private fun initialize() {
         if (rpcToolPath == null) {
             LOG.info("rpctool wasn't found")
             return
         }
 
-        val freezeScript = config.configurationParameters["vmware.freeze.script"].let {
+        val freezeScript: String = config.configurationParameters["vmware.freeze.script"].let {
             if (it.isNullOrEmpty()) {
                 LOG.info("vmware.freeze.script is unset")
                 return
@@ -34,21 +32,7 @@ class VmwareInstacloneAgent(lifeCycleEvents: EventDispatcher<AgentLifeCycleListe
             it
         }
 
-        fun getInstanceConfig(): String? {
-            val executor = CommandLineExecutor(GeneralCommandLine().apply {
-                exePath = rpcToolPath
-                addParameter("info-get guestinfo.teamcity-instance-config")
-            })
-
-            val result = executor.runProcess()
-            if (result.exitCode != 0) {
-                return null
-            }
-
-            return result.stdout.trim()
-        }
-
-        val instanceConfigString = getInstanceConfig().let {
+        val instanceConfigString = callRpcTool("info-get guestinfo.teamcity-instance-config").let {
             if (it.isNullOrEmpty()) {
                 if (config.authorizationToken.isNotEmpty()) {
                     LOG.error("Can't freeze: delete authorization token from build.properties")
@@ -56,10 +40,10 @@ class VmwareInstacloneAgent(lifeCycleEvents: EventDispatcher<AgentLifeCycleListe
                 }
                 LOG.info(String.format("Going to execute the freeze script: %s", freezeScript))
 
-                Runtime.getRuntime().exec(freezeScript).waitFor()
+                exec(freezeScript).waitFor()
 
                 LOG.info("Freeze script completed")
-                val newConfig = getInstanceConfig()
+                val newConfig = callRpcTool("info-get guestinfo.teamcity-instance-config")
                 if (newConfig.isNullOrEmpty()) {
                     LOG.error("Missing guestinfo.teamcity-instance-config in an unfrozen machine")
                     return
@@ -98,7 +82,7 @@ class VmwareInstacloneAgent(lifeCycleEvents: EventDispatcher<AgentLifeCycleListe
             return path
         }
 
-        private val LOG = Logger.getInstance(VmwareInstacloneAgent::class.java.name)
+        private val LOG = Logger.getInstance(RunningAgentPlugin::class.java.name)
         private const val RPC_TOOL_PARAMETER = "teamcity.vmware.rpctool.path"
         private val DEFAULT_PATHS = arrayOf(
                 "C:\\Program Files\\VMware\\VMware Tools\\rpctool.exe",
@@ -106,5 +90,49 @@ class VmwareInstacloneAgent(lifeCycleEvents: EventDispatcher<AgentLifeCycleListe
                 "/usr/bin/vmware-rpctool",
                 "/sbin/rpctool",
                 "/Library/Application Support/VMware Tools/vmware-tools-daemon")
+    }
+
+    override fun shutdown() {
+        val shutdownScript = config.configurationParameters["vmware.shutdown.script"]
+        Thread {
+            LOG.info("Received shutdown signal due to instance being terminated")
+            val agent = this.agent as BuildAgentEx
+            agent.serverMonitor.shutdown()
+            agent.unregisterFromBuildServer()
+            if (shutdownScript != null) {
+                LOG.info(String.format("Going to execute the shutdown script: %s", shutdownScript))
+                try {
+                    exec(shutdownScript).waitFor()
+                } catch (_: Exception) {
+                }
+            }
+
+            LOG.info("Signalling shutdown completion")
+            callRpcTool("info-set guestinfo.teamcity-instance-shutdown true")
+        }.start()
+    }
+
+    private fun callRpcTool(command: String): String? {
+        val executor = CommandLineExecutor(GeneralCommandLine().apply {
+            exePath = rpcToolPath
+            addParameter(command)
+        })
+
+        val result = executor.runProcess()
+        if (result.exitCode != 0) {
+            return null
+        }
+
+        return result.stdout.trim()
+    }
+
+    private fun exec(command: String): Process {
+        val cmdline = org.apache.commons.exec.CommandLine.parse(command)
+        val process = ProcessBuilder(cmdline.executable, *cmdline.arguments)
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+        process.inputStream.close()
+        return process
     }
 }

--- a/vsphere-instaclone-agent/src/main/java/com/avast/teamcity/plugins/instaclone/VmwareInstacloneAgentPlugin.kt
+++ b/vsphere-instaclone-agent/src/main/java/com/avast/teamcity/plugins/instaclone/VmwareInstacloneAgentPlugin.kt
@@ -1,0 +1,20 @@
+package com.avast.teamcity.plugins.instaclone
+
+import jetbrains.buildServer.agent.*
+import jetbrains.buildServer.util.EventDispatcher
+
+class VmwareInstacloneAgentPlugin(
+        lifeCycleEvents: EventDispatcher<AgentLifeCycleListener>,
+        serverCommandsHandlersRegistry: ServerCommandsHandlersRegistry) {
+
+    init {
+        lifeCycleEvents.addListener(object : AgentLifeCycleAdapter() {
+            override fun agentInitialized(agent: BuildAgent) {
+                val runningPlugin = RunningAgentPlugin(agent)
+                serverCommandsHandlersRegistry.registerCommandsHandler(
+                        "vmware-instaclone-agent-service",
+                        runningPlugin)
+            }
+        })
+    }
+}

--- a/vsphere-instaclone-agent/src/main/resources/META-INF/build-agent-plugin-vsphere-instaclone.xml
+++ b/vsphere-instaclone-agent/src/main/resources/META-INF/build-agent-plugin-vsphere-instaclone.xml
@@ -3,5 +3,5 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
        default-autowire="constructor">
-  <bean class="com.avast.teamcity.plugins.instaclone.VmwareInstacloneAgent"/>
+  <bean class="com.avast.teamcity.plugins.instaclone.VmwareInstacloneAgentPlugin"/>
 </beans>

--- a/vsphere-instaclone-common/pom.xml
+++ b/vsphere-instaclone-common/pom.xml
@@ -7,23 +7,10 @@
         <groupId>com.avast.teamcity.plugins</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>vsphere-instaclone-agent</artifactId>
+    <artifactId>vsphere-instaclone-common</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-exec -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.avast.teamcity.plugins</groupId>
-            <artifactId>vsphere-instaclone-common</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-
         <dependency>
             <groupId>com.avast.teamcity.plugins</groupId>
             <artifactId>teamcity-stubs</artifactId>
@@ -31,31 +18,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20190722</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>agent-api</artifactId>
-            <version>${teamcity-version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>cloud-interface</artifactId>
-            <version>${teamcity-version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>cloud-shared</artifactId>
-            <version>${teamcity-version}</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>

--- a/vsphere-instaclone-common/src/main/java/com/avast/teamcity/plugins/instaclone/AgentService.kt
+++ b/vsphere-instaclone-common/src/main/java/com/avast/teamcity/plugins/instaclone/AgentService.kt
@@ -1,0 +1,8 @@
+package com.avast.teamcity.plugins.instaclone
+
+import jetbrains.buildServer.remote.RemoteHandler
+
+@RemoteHandler(handleName = "vmware-instaclone-agent-service")
+interface AgentService {
+    fun shutdown()
+}

--- a/vsphere-instaclone-server/pom.xml
+++ b/vsphere-instaclone-server/pom.xml
@@ -13,6 +13,12 @@
     <dependencies>
         <dependency>
             <groupId>com.avast.teamcity.plugins</groupId>
+            <artifactId>vsphere-instaclone-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.avast.teamcity.plugins</groupId>
             <artifactId>teamcity-stubs</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>

--- a/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudImage.kt
+++ b/vsphere-instaclone-server/src/main/java/com/avast/teamcity/plugins/instaclone/ICCloudImage.kt
@@ -5,6 +5,7 @@ import jetbrains.buildServer.clouds.CloudErrorInfo
 import jetbrains.buildServer.clouds.CloudImage
 import jetbrains.buildServer.clouds.CloudInstance
 import jetbrains.buildServer.clouds.CloudInstanceUserData
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 class ICCloudImage(
@@ -14,6 +15,7 @@ class ICCloudImage(
         val instanceFolder: ManagedObjectReference,
         val maxInstances: Int,
         val networks: List<String>,
+        val shutdownTimeout: Duration,
         private val agentPool: Int?,
         val profile: ICCloudClient) : CloudImage {
 


### PR DESCRIPTION
The agent will now unregister from the server before the virtual machine is destroyed. Furthermore, an optional shutdown script can be configured to run after the agent unregisters.